### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/kristof12345/Launchpad/security/code-scanning/3](https://github.com/kristof12345/Launchpad/security/code-scanning/3)

To resolve the issue, you should add an explicit `permissions` block to the workflow YAML file. This can either be at the workflow root (applies to all jobs), or to the specific job (in this case, `build-and-test`). Since the provided workflow does not need to perform any write actions to the repository, the most restrictive sensible setting is `permissions: contents: read`. The best practice is to place this block at the workflow root level, just after the `name` declaration, to apply it everywhere unless exceptions are needed. No further changes are required outside this addition.

Edit `.github/workflows/ci.yml` to insert the following block at line 2 (after `name: CI`):

```yaml
permissions:
  contents: read
```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
