### PR TITLE
Fix: Improve navigation app selection and SearchResultView scrolling

### DIFF
--- a/Launchpad/Components/Search/SearchResultsView.swift
+++ b/Launchpad/Components/Search/SearchResultsView.swift
@@ -9,39 +9,69 @@ struct SearchResultsView: View {
    var body: some View {
       GeometryReader { geo in
          let layout = LayoutMetrics(size: geo.size, columns: settings.columns, rows: settings.rows, iconSize: settings.iconSize)
-         
+         let shouldCenterAlign = apps.count < settings.columns
+
          if apps.isEmpty {
             EmptySearchView()
          } else {
-            ScrollView(.vertical, showsIndicators: false) {
-               LazyVGrid(
-                  columns: GridLayoutUtility.createGridColumns(count: settings.columns, cellWidth: layout.cellWidth, spacing: layout.hSpacing),
-                  spacing: layout.hSpacing
-               ) {
-                  ForEach(Array(apps.enumerated()), id: \.element.id) { index, app in
-                     AppIconView(app: app, layout: layout, isDragged: false)
-                        .background(
-                           RoundedRectangle(cornerRadius: 12)
-                              .fill(index == selectedIndex ? Color.gray.opacity(0.3) : Color.clear)
-                              .padding(-8)
-                              .aspectRatio(1.0, contentMode: .fit)
-                        )
-                        .onTapGesture {
-                           onItemTap(.app(app))
-                        }
-                        .contextMenu {
-                           Button(action: {
-                              AppManager.shared.hideApp(path: app.path, appsPerPage: settings.appsPerPage)
-                           }) {
-                              Label(L10n.hideApp, systemImage: "eye.slash")
+            ScrollViewReader { proxy in
+               ScrollView(.vertical, showsIndicators: false) {
+                  Group {
+                     if shouldCenterAlign {
+                        HStack {
+                           Spacer()
+                           LazyVGrid(
+                              columns: GridLayoutUtility.createGridColumns(count: apps.count, cellWidth: layout.cellWidth, spacing: layout.hSpacing),
+                              spacing: layout.hSpacing
+                           ) {
+                              gridContent(layout: layout)
                            }
+                           Spacer()
                         }
+                     } else {
+                        LazyVGrid(
+                           columns: GridLayoutUtility.createGridColumns(count: settings.columns, cellWidth: layout.cellWidth, spacing: layout.hSpacing),
+                           spacing: layout.hSpacing
+                        ) {
+                           gridContent(layout: layout)
+                        }
+                     }
+                  }
+                  .padding(.horizontal, layout.hPadding)
+                  .padding(.vertical, layout.vPadding)
+               }
+               .onChange(of: selectedIndex) { _, newIndex in
+                  guard newIndex >= 0 && newIndex < apps.count else { return }
+                  withAnimation(.easeInOut(duration: 0.2)) {
+                     proxy.scrollTo(apps[newIndex].id, anchor: .center)
                   }
                }
-               .padding(.horizontal, layout.hPadding)
-               .padding(.vertical, layout.vPadding)
             }
          }
+      }
+   }
+
+   @ViewBuilder
+   private func gridContent(layout: LayoutMetrics) -> some View {
+      ForEach(Array(apps.enumerated()), id: \.element.id) { index, app in
+         AppIconView(app: app, layout: layout, isDragged: false)
+            .id(app.id)
+            .background(
+               RoundedRectangle(cornerRadius: 12)
+                  .fill(index == selectedIndex ? Color.gray.opacity(0.3) : Color.clear)
+                  .padding(-8)
+                  .aspectRatio(1.0, contentMode: .fit)
+            )
+            .onTapGesture {
+               onItemTap(.app(app))
+            }
+            .contextMenu {
+               Button(action: {
+                  AppManager.shared.hideApp(path: app.path, appsPerPage: settings.appsPerPage)
+               }) {
+                  Label(L10n.hideApp, systemImage: "eye.slash")
+               }
+            }
       }
    }
 }


### PR DESCRIPTION
### Description
After introducing the navigation app selection using buttons — allowing users to choose which app to open instead of automatically launching the first one — a few issues were observed and fixed:

### Bug Fix:
SearchResultsView wasn’t scrolling down properly.
→ Added ScrollViewReader with ID-based scrolling to ensure smooth navigation through results.

### UI Improvement:
Apps are now center-aligned only when the total number of apps is less than the number of columns.
This improves layout consistency across different grid configurations.

### Preview
https://github.com/user-attachments/assets/ae06232c-8705-43df-8a8c-48f3ccaf0c26


https://github.com/user-attachments/assets/ba2d0e10-0402-459c-a1ca-b34a12a0435f

